### PR TITLE
Add ability to configure default serializer

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,7 +7,7 @@
     <Trademark>$(Company)™</Trademark>
 	<Product>XperienceCommunity.FusionCache</Product>
 	<Title>$(Product)</Title>
-    <VersionPrefix>1.0.0</VersionPrefix>
+    <VersionPrefix>1.1.0</VersionPrefix>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/craftedmedia/XperienceCommunity.FusionCache</PackageProjectUrl>
     <PackageReleaseNotes>https://github.com/craftedmedia/XperienceCommunity.FusionCache/releases</PackageReleaseNotes>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -10,8 +10,13 @@
 	<PackageVersion Include="Kentico.Xperience.WebApp" Version="30.0.0" />
 	<PackageVersion Include="Microsoft.AspNetCore.Mvc.TagHelpers" Version="2.3.0" />
 	<PackageVersion Include="Microsoft.Extensions.Caching.StackExchangeRedis" Version="9.0.0" />
-	<PackageVersion Include="ZiggyCreatures.FusionCache" Version="2.0.0" />
-	<PackageVersion Include="ZiggyCreatures.FusionCache.Backplane.StackExchangeRedis" Version="2.0.0" />
-	<PackageVersion Include="ZiggyCreatures.FusionCache.Serialization.NeueccMessagePack" Version="2.0.0" />
+	<PackageVersion Include="ZiggyCreatures.FusionCache" Version="2.1.0" />
+	<PackageVersion Include="ZiggyCreatures.FusionCache.Backplane.StackExchangeRedis" Version="2.1.0" />
+	<PackageVersion Include="ZiggyCreatures.FusionCache.Serialization.NewtonsoftJson" Version="2.1.0" />
+	<PackageVersion Include="ZiggyCreatures.FusionCache.Serialization.NeueccMessagePack" Version="2.1.0" />
+	<PackageVersion Include="ZiggyCreatures.FusionCache.Serialization.CysharpMemoryPack" Version="2.1.0" />
+	<PackageVersion Include="ZiggyCreatures.FusionCache.Serialization.SystemTextJson" Version="2.1.0" />
+	<PackageVersion Include="ZiggyCreatures.FusionCache.Serialization.ServiceStackJson" Version="2.1.0" />
+	<PackageVersion Include="ZiggyCreatures.FusionCache.Serialization.ProtoBufNet" Version="2.1.0" />
   </ItemGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -126,6 +126,27 @@ Example:
 
 Any option available on the [FusionCacheEntryOptions](https://github.com/ZiggyCreatures/FusionCache/blob/f3896a5f5b6e21f918009d687520938d322f79f4/src/ZiggyCreatures.FusionCache/FusionCacheEntryOptions.cs) is also available to be set here.
 
+### Configuring Serialization
+[NewtonsoftJson](https://www.nuget.org/packages/ZiggyCreatures.FusionCache.Serialization.NewtonsoftJson/) is configured as the default serializer for maximum compatibility and ease of use, however it's possible to configure any of the following serializers:
+
+- [SystemTextJson](https://www.nuget.org/packages/ZiggyCreatures.FusionCache.Serialization.SystemTextJson)
+- [CysharpMemoryPack](https://www.nuget.org/packages/ZiggyCreatures.FusionCache.Serialization.CysharpMemoryPack)
+- [NeueccMessagePack](https://www.nuget.org/packages/ZiggyCreatures.FusionCache.Serialization.NeueccMessagePack)
+- [ServiceStackJson](https://www.nuget.org/packages/ZiggyCreatures.FusionCache.Serialization.ServiceStackJson)
+- [ProtoBufNet](https://www.nuget.org/packages/ZiggyCreatures.FusionCache.Serialization.ProtoBufNet)
+
+See https://github.com/ZiggyCreatures/FusionCache/pull/349 for performance benchmarks for each of these serializers.
+
+To configure a different serializer, simply specify the `DefaultSerializer` in options:
+```
+"XperienceFusionCache": {
+  "RedisConnectionString": "...",
+  "DefaultSerializer": "NeueccMessagePack" // OR 'ServiceStackJson' etc...
+},
+```
+`FusionCache` will now use the configured serializer instead of the default. Each serializer has its pros, cons and individual quirks you should familiarize yourself with before using.
+
+
 ### Fusion Cache Tag Helper
 
 The package provides a custom cache tag helper backed by `FusionCache`.

--- a/src/OutputCache/XperienceCommunityFusionCacheOutputCacheStore.cs
+++ b/src/OutputCache/XperienceCommunityFusionCacheOutputCacheStore.cs
@@ -23,12 +23,7 @@ internal class XperienceCommunityFusionCacheOutputCacheStore : IOutputCacheStore
     /// <param name="tag">The tag to evict.</param>
     /// <param name="cancellationToken">Indicates that the operation should be cancelled.</param>
     /// <returns><see cref="ValueTask"/>.</returns>
-    public ValueTask EvictByTagAsync(string tag, CancellationToken cancellationToken)
-    {
-        fusionCache.RemoveByTag(tag, token: cancellationToken);
-
-        return ValueTask.CompletedTask;
-    }
+    public async ValueTask EvictByTagAsync(string tag, CancellationToken cancellationToken) => await fusionCache.RemoveByTagAsync(tag, token: cancellationToken);
 
     /// <summary>
     /// Gets the cached response for the given key, if it exists.
@@ -37,17 +32,7 @@ internal class XperienceCommunityFusionCacheOutputCacheStore : IOutputCacheStore
     /// <param name="key">The cache key to look up.</param>
     /// <param name="cancellationToken">Indicates that the operation should be cancelled.</param>
     /// <returns>The response cache entry if it exists; otherwise <c>null</c>.</returns>
-    public async ValueTask<byte[]?> GetAsync(string key, CancellationToken cancellationToken)
-    {
-        var cacheEntry = await fusionCache.TryGetAsync<byte[]>(key, token: cancellationToken);
-
-        if (!cacheEntry.HasValue)
-        {
-            return null;
-        }
-
-        return cacheEntry.Value;
-    }
+    public async ValueTask<byte[]?> GetAsync(string key, CancellationToken cancellationToken) => await fusionCache.GetOrDefaultAsync<byte[]?>(key, null, token: cancellationToken);
 
     /// <summary>
     /// Stores the given response in the response cache.
@@ -58,5 +43,5 @@ internal class XperienceCommunityFusionCacheOutputCacheStore : IOutputCacheStore
     /// <param name="validFor">The amount of time the entry will be kept in the cache before expiring, relative to now.</param>
     /// <param name="cancellationToken">Indicates that the operation should be cancelled.</param>
     /// <returns><see cref="ValueTask"/>.</returns>
-    public async ValueTask SetAsync(string key, byte[] value, string[]? tags, TimeSpan validFor, CancellationToken cancellationToken) => await fusionCache.SetAsync(key, value, opts => opts.SetDuration(validFor), tags: tags, token: cancellationToken);
+    public async ValueTask SetAsync(string key, byte[] value, string[]? tags, TimeSpan validFor, CancellationToken cancellationToken) => await fusionCache.SetAsync(key, value, opts => opts.SetDuration(validFor).SetSize(value.Length), tags: tags, token: cancellationToken);
 }

--- a/src/Services/FusionCacheTagHelperService.cs
+++ b/src/Services/FusionCacheTagHelperService.cs
@@ -53,7 +53,7 @@ public partial class FusionCacheTagHelperService
     /// <param name="key">The key in the storage.</param>
     /// <param name="options">Cache options.</param>
     /// <returns>A cached or new content for the cache tag helper.</returns>
-    public async Task<HtmlString> ProcessContentAsync(
+    public async ValueTask<HtmlString> ProcessContentAsync(
         TagHelperOutput tagHelperOutput,
         FusionCacheTagKey key,
         XperienceFusionCacheTagHelperOptions options)

--- a/src/XperienceCommunity.FusionCache.csproj
+++ b/src/XperienceCommunity.FusionCache.csproj
@@ -20,7 +20,12 @@
 		<PackageReference Include="Microsoft.Extensions.Caching.StackExchangeRedis" />
 		<PackageReference Include="ZiggyCreatures.FusionCache" />
 		<PackageReference Include="ZiggyCreatures.FusionCache.Backplane.StackExchangeRedis" />
+		<PackageReference Include="ZiggyCreatures.FusionCache.Serialization.NewtonsoftJson" />
 		<PackageReference Include="ZiggyCreatures.FusionCache.Serialization.NeueccMessagePack" />
+		<PackageReference Include="ZiggyCreatures.FusionCache.Serialization.CysharpMemoryPack" />
+		<PackageReference Include="ZiggyCreatures.FusionCache.Serialization.SystemTextJson" />
+		<PackageReference Include="ZiggyCreatures.FusionCache.Serialization.ServiceStackJson" />
+		<PackageReference Include="ZiggyCreatures.FusionCache.Serialization.ProtoBufNet" />
 	</ItemGroup>
 
 </Project>

--- a/src/XperienceCommunityFusionCache.cs
+++ b/src/XperienceCommunityFusionCache.cs
@@ -12,7 +12,13 @@ using XperienceCommunity.FusionCache.Utilities;
 
 using ZiggyCreatures.Caching.Fusion;
 using ZiggyCreatures.Caching.Fusion.Backplane.StackExchangeRedis;
+using ZiggyCreatures.Caching.Fusion.Serialization;
+using ZiggyCreatures.Caching.Fusion.Serialization.CysharpMemoryPack;
 using ZiggyCreatures.Caching.Fusion.Serialization.NeueccMessagePack;
+using ZiggyCreatures.Caching.Fusion.Serialization.NewtonsoftJson;
+using ZiggyCreatures.Caching.Fusion.Serialization.ProtoBufNet;
+using ZiggyCreatures.Caching.Fusion.Serialization.ServiceStackJson;
+using ZiggyCreatures.Caching.Fusion.Serialization.SystemTextJson;
 
 namespace XperienceCommunity.FusionCache;
 
@@ -55,7 +61,7 @@ public static class XperienceCommunityFusionCache
         // Configure fusion cache, and redis as our L2 cache.
         services.AddFusionCache()
                 .WithDefaultEntryOptions(options.DefaultFusionCacheEntryOptions)
-                .WithSerializer(new FusionCacheNeueccMessagePackSerializer())
+                .WithSerializer(GetConfiguredSerializer(options.DefaultSerializer))
                 .WithDistributedCache(new RedisCache(new RedisCacheOptions() { Configuration = options.RedisConnectionString }))
                 .WithBackplane(new RedisBackplane(new RedisBackplaneOptions() { Configuration = options.RedisConnectionString }));
 
@@ -93,4 +99,14 @@ public static class XperienceCommunityFusionCache
 
         return app;
     }
+
+    private static IFusionCacheSerializer GetConfiguredSerializer(string serializer) => serializer switch
+    {
+        "NeueccMessagePack" => new FusionCacheNeueccMessagePackSerializer(),
+        "CysharpMemoryPack" => new FusionCacheCysharpMemoryPackSerializer(),
+        "SystemTextJson" => new FusionCacheSystemTextJsonSerializer(),
+        "ServiceStackJson" => new FusionCacheServiceStackJsonSerializer(),
+        "ProtoBufNet" => new FusionCacheProtoBufNetSerializer(),
+        _ => new FusionCacheNewtonsoftJsonSerializer(),
+    };
 }

--- a/src/XperienceCommunityFusionCacheOptions.cs
+++ b/src/XperienceCommunityFusionCacheOptions.cs
@@ -28,5 +28,10 @@ namespace XperienceCommunity.FusionCache
         /// Gets or sets the default fusion cache entry options.
         /// </summary>
         public FusionCacheEntryOptions? DefaultFusionCacheEntryOptions { get; set; }
+
+        /// <summary>
+        /// Gets or sets the default serializer to use.
+        /// </summary>
+        public string DefaultSerializer { get; set; } = "NewtonsoftJson";
     }
 }

--- a/src/packages.lock.json
+++ b/src/packages.lock.json
@@ -68,31 +68,81 @@
       },
       "ZiggyCreatures.FusionCache": {
         "type": "Direct",
-        "requested": "[2.0.0, )",
-        "resolved": "2.0.0",
-        "contentHash": "fwUwz4iS9Avq5oh7AI01/RktdG4yEp/jlCrlcq1ww6/mCoQzxq5dJDZhyhLVdx0s7MN22rUW3N+huGYXignrMA==",
+        "requested": "[2.1.0, )",
+        "resolved": "2.1.0",
+        "contentHash": "dlaO86jRZxggegGw/memJC5QSkZ7+o+RJFv/ZxhikAiYgnO12Nu3x62RX3LdyADd/pz6h4eAwTrZCrtaW33sgw==",
         "dependencies": {
           "Microsoft.Extensions.Caching.Memory": "9.0.0"
         }
       },
       "ZiggyCreatures.FusionCache.Backplane.StackExchangeRedis": {
         "type": "Direct",
-        "requested": "[2.0.0, )",
-        "resolved": "2.0.0",
-        "contentHash": "NPAeTTxux3YH5UP7YrK97fZ3taIjqaraKcmTHacXBXO3C1uKjCtNUPtpATdzSXR+SKkqMemQOvAvi9kGU/xkcQ==",
+        "requested": "[2.1.0, )",
+        "resolved": "2.1.0",
+        "contentHash": "O6+lea9lwM3xveads2heux4zFDTLR57fCNpE+fZyVm/UXPkKgnP53mPq6sYIhr+ggp6aZvtKMSnSV3mALJ4A3g==",
         "dependencies": {
           "StackExchange.Redis": "2.8.22",
-          "ZiggyCreatures.FusionCache": "2.0.0"
+          "ZiggyCreatures.FusionCache": "2.1.0"
+        }
+      },
+      "ZiggyCreatures.FusionCache.Serialization.CysharpMemoryPack": {
+        "type": "Direct",
+        "requested": "[2.1.0, )",
+        "resolved": "2.1.0",
+        "contentHash": "aOfaCjJUFFYNjJ3hNxycsOYE1NwknFaOSyBdZJknDTLyLBi0+HRC1bN4x5S4ALloWGOaJ0JiyC/+KxmgaqZnTw==",
+        "dependencies": {
+          "MemoryPack": "1.21.3",
+          "ZiggyCreatures.FusionCache": "2.1.0"
         }
       },
       "ZiggyCreatures.FusionCache.Serialization.NeueccMessagePack": {
         "type": "Direct",
-        "requested": "[2.0.0, )",
-        "resolved": "2.0.0",
-        "contentHash": "gYP4oKQqzg18nqiJQvEkkD8KkXXwjWsTbkQqu0xGDaC3YAEtE8+oRNXy/BzkKuOQiHadBRu9PnSNtYbiBUiRqw==",
+        "requested": "[2.1.0, )",
+        "resolved": "2.1.0",
+        "contentHash": "T5KY/BXdVDncJN3npZh6CZm5rb/n8oDSbmqu1I8aTElVhmjmGtX4KQBBpO/+ipYu6c2l1Jfn178afN+Rjc43SQ==",
         "dependencies": {
           "MessagePack": "3.0.308",
-          "ZiggyCreatures.FusionCache": "2.0.0"
+          "ZiggyCreatures.FusionCache": "2.1.0"
+        }
+      },
+      "ZiggyCreatures.FusionCache.Serialization.NewtonsoftJson": {
+        "type": "Direct",
+        "requested": "[2.1.0, )",
+        "resolved": "2.1.0",
+        "contentHash": "cfc3hrQ4VhyK3iuIlwCMd3MhVD3jE4a6s3FvqUHyryo0k4JXuHcjxd0lUVbKpkDBJpWFrCG/kIIE2H1zU4k3DA==",
+        "dependencies": {
+          "Newtonsoft.Json": "13.0.3",
+          "ZiggyCreatures.FusionCache": "2.1.0"
+        }
+      },
+      "ZiggyCreatures.FusionCache.Serialization.ProtoBufNet": {
+        "type": "Direct",
+        "requested": "[2.1.0, )",
+        "resolved": "2.1.0",
+        "contentHash": "A/a8Na798qsOx3oSdrFdCZOKgjEYC22Wq+mjs15ExhoBjA9IW20MoQqNfTfJMNxDJVgahe55KaRa/xeMHkSbbw==",
+        "dependencies": {
+          "ZiggyCreatures.FusionCache": "2.1.0",
+          "protobuf-net": "3.2.46"
+        }
+      },
+      "ZiggyCreatures.FusionCache.Serialization.ServiceStackJson": {
+        "type": "Direct",
+        "requested": "[2.1.0, )",
+        "resolved": "2.1.0",
+        "contentHash": "05fwZg0RJSYLXcCsq017udEgy2RTn5NudoScrdLHopOFgg8UofDEV8RQ11omvDARtWAFj9JiWIIP0GzmdhaKuA==",
+        "dependencies": {
+          "ServiceStack.Text": "8.5.2",
+          "ZiggyCreatures.FusionCache": "2.1.0"
+        }
+      },
+      "ZiggyCreatures.FusionCache.Serialization.SystemTextJson": {
+        "type": "Direct",
+        "requested": "[2.1.0, )",
+        "resolved": "2.1.0",
+        "contentHash": "BSmmQZ6c/0r2fVLDW1hGtywygJV1i+5zBsgvy6gAlSeY0DjwpVxXBftjRTgf3VpsZ2ca4Zi2bopW5CTYCSRWUA==",
+        "dependencies": {
+          "System.Text.Json": "8.0.5",
+          "ZiggyCreatures.FusionCache": "2.1.0"
         }
       },
       "AngleSharp": {
@@ -437,6 +487,25 @@
           "MimeKit": "4.8.0",
           "System.Formats.Asn1": "8.0.1"
         }
+      },
+      "MemoryPack": {
+        "type": "Transitive",
+        "resolved": "1.21.3",
+        "contentHash": "cwCtED8y400vMWx/Vp0QCSeEpVFjDU4JwF52VX9WTaqVERUvNqjG9n6osFlmFuytegyXnHvYEu1qRJ8rv/rkbg==",
+        "dependencies": {
+          "MemoryPack.Core": "1.21.3",
+          "MemoryPack.Generator": "1.21.3"
+        }
+      },
+      "MemoryPack.Core": {
+        "type": "Transitive",
+        "resolved": "1.21.3",
+        "contentHash": "ajrYoBWT2aKeH4tlY8q/1C9qK1R/NK+7FkuVOX58ebOSxkABoFTqCR7W+Zk2rakUHZiEgNdRqO67hiRZPq6fLA=="
+      },
+      "MemoryPack.Generator": {
+        "type": "Transitive",
+        "resolved": "1.21.3",
+        "contentHash": "hYU0TAIarDKnbkNIWvb7P4zBUL+CTahkuNkczsKvycSMR5kiwQ4IfLexywNKX3s05Izp4gzDSPbueepNWZRpWA=="
       },
       "MessagePack": {
         "type": "Transitive",
@@ -838,8 +907,8 @@
       },
       "Microsoft.CSharp": {
         "type": "Transitive",
-        "resolved": "4.5.0",
-        "contentHash": "kaj6Wb4qoMuH3HySFJhxwQfe8R/sJsNJnANrvv8WdFPMoNbKY5htfNscv+LHCu5ipz+49m2e+WQXpLXr9XYemQ=="
+        "resolved": "4.7.0",
+        "contentHash": "pTj+D3uJWyN3My70i2Hqo+OXixq3Os2D1nJ2x92FFo6sk8fYS1m1WLNTs0Dc1uPaViH0YvEEwvzddQ7y4rhXmA=="
       },
       "Microsoft.Data.SqlClient": {
         "type": "Transitive",
@@ -1216,6 +1285,22 @@
           "System.IO.Pipelines": "5.0.1"
         }
       },
+      "protobuf-net": {
+        "type": "Transitive",
+        "resolved": "3.2.46",
+        "contentHash": "kNr1fnLWTVNvK93SC1CFrV3TyNDrtrqtoAv7+V4WX3c/tckzmIISW0Hl5TV5GgIYL5rrFeUEYWNHQZDCHpSMzQ==",
+        "dependencies": {
+          "protobuf-net.Core": "3.2.46"
+        }
+      },
+      "protobuf-net.Core": {
+        "type": "Transitive",
+        "resolved": "3.2.46",
+        "contentHash": "kRPJ71Bpj0nK2iRSnH6XTPCA0+Nal5xoVBKwFqgd5n/yVA7Iie/3KwvcmC+aFjTymh+Kibn4q4fnceIOJrKRlA==",
+        "dependencies": {
+          "System.Collections.Immutable": "7.0.0"
+        }
+      },
       "runtime.debian.8-x64.runtime.native.System.Security.Cryptography.OpenSsl": {
         "type": "Transitive",
         "resolved": "4.3.0",
@@ -1322,6 +1407,16 @@
         "type": "Transitive",
         "resolved": "4.3.0",
         "contentHash": "VB5cn/7OzUfzdnC8tqAIMQciVLiq2epm2NrAm1E9OjNRyG4lVhfR61SMcLizejzQP8R8Uf/0l5qOIbUEi+RdEg=="
+      },
+      "ServiceStack.Text": {
+        "type": "Transitive",
+        "resolved": "8.5.2",
+        "contentHash": "BHSJMxh+rIv7cgAqDHXl3FJM3xoY+SCN8CqiKjR5+AUb1ZK9lrJtGjzKYIo+5AQSD0lQDBjWxhYXcqE8ST+Rbw==",
+        "dependencies": {
+          "Microsoft.CSharp": "4.7.0",
+          "System.Diagnostics.DiagnosticSource": "8.0.0",
+          "System.Memory": "4.6.0"
+        }
       },
       "StackExchange.Redis": {
         "type": "Transitive",
@@ -1645,8 +1740,8 @@
       },
       "System.Memory": {
         "type": "Transitive",
-        "resolved": "4.5.4",
-        "contentHash": "1MbJTHS1lZ4bS4FmsJjnuGJOu88ZzTT2rLvrhW7Ygic+pC0NWA+3hgAen0HRdsocuQXCkUTdFn9yHJJhsijDXw=="
+        "resolved": "4.6.0",
+        "contentHash": "OEkbBQoklHngJ8UD8ez2AERSk2g+/qpAaSWWCBFbpH727HxDq5ydVkuncBaKcKfwRqXGWx64dS6G1SUScMsitg=="
       },
       "System.Memory.Data": {
         "type": "Transitive",


### PR DESCRIPTION
- Added the ability to configure a default serializer
- Minor performance tweak, swapping `Task<T>` for `ValueTask<T>` in tag helper service
- Bump `FusionCache` package version